### PR TITLE
Add `replies:populate` task

### DIFF
--- a/lib/discourse_dev/post.rb
+++ b/lib/discourse_dev/post.rb
@@ -50,5 +50,39 @@ module DiscourseDev
         create!
       end
     end
+
+    def self.add_replies!(args)
+      if !args[:topic_id]
+        puts "Topic ID is required. Aborting."
+        return
+      end
+
+      if !::Topic.find_by_id(args[:topic_id])
+        puts "Topic ID does not match topic in DB, aborting."
+        return
+      end
+
+      topic = ::Topic.find_by_id(args[:topic_id])
+      count = args[:count] ? args[:count].to_i : 50
+
+      puts "Creating #{count} replies in '#{topic.title}'"
+
+      count.times do |i|
+        @index = i
+        begin
+          reply = {
+            topic_id: topic.id,
+            raw: Faker::Markdown.sandwich(sentences: 5),
+            skip_validations: true
+          }
+          PostCreator.new(User.random, reply).create!
+        rescue ActiveRecord::RecordNotSaved => e
+          puts e
+        end
+      end
+
+      puts "Done!"
+    end
+
   end
 end

--- a/lib/discourse_dev/tasks/populate.rake
+++ b/lib/discourse_dev/tasks/populate.rake
@@ -24,3 +24,8 @@ desc 'Creates sample topics'
 task 'topics:populate' => ['db:load_config'] do |_, args|
   DiscourseDev::Topic.populate!
 end
+
+desc 'Add replies to a topic'
+task 'replies:populate', [:topic_id, :count] => ['db:load_config'] do |_, args|
+  DiscourseDev::Post.add_replies!(args)
+end

--- a/lib/discourse_dev/version.rb
+++ b/lib/discourse_dev/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DiscourseDev
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
Adds a standalone task to populate replies on a given topic. 

Example usage: 

```
bin/rake replies:populate[123] # creates 50 new replies on topic with id 123

bin/rake replies:populate[62,100] # creates 100 new replies on topic with id 62

```
